### PR TITLE
Modified hw3/model_wrapper.py fix pytorch 0.5 version compatibility

### DIFF
--- a/hw3/model_wrapper.py
+++ b/hw3/model_wrapper.py
@@ -28,7 +28,7 @@ class Wrapper(object):
     def accuracy(self, prediction, reference):
         prediction = prediction.max(1)[1].type(torch.LongTensor)
         reference = reference.cpu()
-        correct = (prediction == reference).sum().data[0]
+        correct = (prediction == reference).sum().item()
 
         return correct/float(prediction.size(0))
 
@@ -60,7 +60,7 @@ class Wrapper(object):
 
             output_list.append(output.cpu().data.numpy())
             total_acc += acc
-            total_loss += loss.data[0]
+            total_loss += loss.item()
 
         total_output = np.concatenate(output_list).argmax(axis=1)
         total_acc = total_acc/x.shape[0]


### PR DESCRIPTION
In pytorch>=0.5, tensor.data[0] with zero dimensional tensor gives wrong value.
Fix: tensor.data[0] -> tensor.item()

UserWarning: invalid index of a 0-dim tensor. This will be an error in PyTorch 0.5. Use tensor.item() to convert a 0-dim tensor to a Python number